### PR TITLE
Event tracking

### DIFF
--- a/components/MainMenu/types/index.d.ts
+++ b/components/MainMenu/types/index.d.ts
@@ -3,6 +3,7 @@ import { BurgerIconStyles } from "./BurgerIconProps";
 declare global {
   interface Window {
     mina: any;
+    gtag: any;
   }
 }
 export type Path = {

--- a/components/SearchBar/SearchBar.tsx
+++ b/components/SearchBar/SearchBar.tsx
@@ -28,7 +28,7 @@ import AutoComplete from "../AutoComplete";
 import { useRouter } from "next/router";
 import { useOnClickOutside } from "../../hooks";
 import { SearchBarProps } from "./types";
-import * as tracking from '../../config/tracking';
+import * as tracking from "../../config/tracking";
 
 const SearchBar = ({
   placeholder = "Search...",
@@ -97,7 +97,7 @@ const SearchBar = ({
       case "Enter":
         if (query.length > 3) {
           if (event.key === "Enter" && query.length > 3) {
-            tracking.trackEvent({action: 'press-enter', category: 'search-bar', label: query});
+            tracking.trackEvent({ action: "press-enter", category: "search-bar", label: query });
 
             router.push(`/search?term=${query}`);
           }
@@ -110,10 +110,10 @@ const SearchBar = ({
   };
 
   const selectSuggestion = (suggestion: string) => {
-    tracking.trackEvent({action: 'select-suggestion', category: 'search-bar', label: suggestion});
+    tracking.trackEvent({ action: "select-suggestion", category: "search-bar", label: suggestion });
 
     setQuery(suggestion);
-  }
+  };
 
   const labelId = "label-search";
   const dropdownId = "dropdown-search";

--- a/components/SearchBar/SearchBar.tsx
+++ b/components/SearchBar/SearchBar.tsx
@@ -97,7 +97,7 @@ const SearchBar = ({
       case "Enter":
         if (query.length > 3) {
           if (event.key === "Enter" && query.length > 3) {
-            tracking.trackEvent({ action: "press-enter", category: "search-bar", label: query });
+            tracking.trackEvent({ action: tracking.Action.PRESS_ENTER, category: tracking.Category.SEARCH_BAR, label: query });
 
             router.push(`/search?term=${query}`);
           }
@@ -110,7 +110,7 @@ const SearchBar = ({
   };
 
   const selectSuggestion = (suggestion: string) => {
-    tracking.trackEvent({ action: "select-suggestion", category: "search-bar", label: suggestion });
+    tracking.trackEvent({ action: tracking.Action.SELECT_SUGGESTION, category: tracking.Category.SEARCH_BAR, label: suggestion });
 
     setQuery(suggestion);
   };

--- a/components/SearchBar/SearchBar.tsx
+++ b/components/SearchBar/SearchBar.tsx
@@ -28,6 +28,7 @@ import AutoComplete from "../AutoComplete";
 import { useRouter } from "next/router";
 import { useOnClickOutside } from "../../hooks";
 import { SearchBarProps } from "./types";
+import * as tracking from '../../config/tracking';
 
 const SearchBar = ({
   placeholder = "Search...",
@@ -96,6 +97,8 @@ const SearchBar = ({
       case "Enter":
         if (query.length > 3) {
           if (event.key === "Enter" && query.length > 3) {
+            tracking.trackEvent({action: 'press-enter', category: 'search-bar', label: query});
+
             router.push(`/search?term=${query}`);
           }
         }
@@ -105,6 +108,12 @@ const SearchBar = ({
         break;
     }
   };
+
+  const selectSuggestion = (suggestion: string) => {
+    tracking.trackEvent({action: 'select-suggestion', category: 'search-bar', label: suggestion});
+
+    setQuery(suggestion);
+  }
 
   const labelId = "label-search";
   const dropdownId = "dropdown-search";
@@ -162,7 +171,7 @@ const SearchBar = ({
           toggleVisibility={(e: any) => setIsAutocompleteVisible(e)}
           id={dropdownId}
           labelId={labelId}
-          onSelect={(e: any) => setQuery(e)}
+          onSelect={(e: any) => selectSuggestion(e)}
           query={query}
         />
       ) : null}

--- a/components/SearchBar/SearchBar.tsx
+++ b/components/SearchBar/SearchBar.tsx
@@ -97,7 +97,11 @@ const SearchBar = ({
       case "Enter":
         if (query.length > 3) {
           if (event.key === "Enter" && query.length > 3) {
-            tracking.trackEvent({ action: tracking.Action.PRESS_ENTER, category: tracking.Category.SEARCH_BAR, label: query });
+            tracking.trackEvent({
+              action: tracking.Action.PRESS_ENTER,
+              category: tracking.Category.SEARCH_BAR,
+              label: query
+            });
 
             router.push(`/search?term=${query}`);
           }
@@ -110,7 +114,11 @@ const SearchBar = ({
   };
 
   const selectSuggestion = (suggestion: string) => {
-    tracking.trackEvent({ action: tracking.Action.SELECT_SUGGESTION, category: tracking.Category.SEARCH_BAR, label: suggestion });
+    tracking.trackEvent({
+      action: tracking.Action.SELECT_SUGGESTION,
+      category: tracking.Category.SEARCH_BAR,
+      label: suggestion
+    });
 
     setQuery(suggestion);
   };

--- a/config/tracking.ts
+++ b/config/tracking.ts
@@ -1,6 +1,17 @@
 export const GA_TRACKING_CODE = process.env.GA_TRACKING_CODE;
 export const GA_DEBUG_MODE = process.env.GA_DEBUG_MODE;
 
+export enum Action {
+  PRESS_ENTER = "press-enter",
+  SELECT_SUGGESTION = "select-suggestion",
+  VIEW_PRODUCT = "view-product"
+}
+
+export enum Category {
+    SEARCH_BAR = "search-bar",
+    PRODUCT_DETAIL = "product-detail"
+}
+
 const TRACKING_ON = process.env.TRACKING !== "off";
 const TRACKING_VERBOSE = process.env.TRACKING_VERBOSE === "on";
 

--- a/config/tracking.ts
+++ b/config/tracking.ts
@@ -8,8 +8,8 @@ export enum Action {
 }
 
 export enum Category {
-    SEARCH_BAR = "search-bar",
-    PRODUCT_DETAIL = "product-detail"
+  SEARCH_BAR = "search-bar",
+  PRODUCT_DETAIL = "product-detail"
 }
 
 const TRACKING_ON = process.env.TRACKING !== "off";

--- a/config/tracking.tsx
+++ b/config/tracking.tsx
@@ -1,12 +1,11 @@
-
 export const GA_TRACKING_CODE = process.env.GA_TRACKING_CODE;
 export const GA_DEBUG_MODE = process.env.GA_DEBUG_MODE;
 
-const TRACKING_ON = process.env.TRACKING !== 'off';
-const TRACKING_VERBOSE = process.env.TRACKING_VERBOSE === 'on';
+const TRACKING_ON = process.env.TRACKING !== "off";
+const TRACKING_VERBOSE = process.env.TRACKING_VERBOSE === "on";
 
-const TRACKING_GA_ON = process.env.TRACKING_PROVIDER_GA !== 'off';
-const TRACKING_KM_ON = process.env.TRACKING_PROVIDER_KM !== 'off';
+const TRACKING_GA_ON = process.env.TRACKING_PROVIDER_GA !== "off";
+const TRACKING_KM_ON = process.env.TRACKING_PROVIDER_KM !== "off";
 
 type TrackingEvent = {
   action: string;
@@ -18,40 +17,34 @@ interface TrackingProvider {
   getName(): string;
   isActive(): boolean;
   trackPageview(url: string): void;
-  trackEvent({action, category, label}: TrackingEvent): void;
-};
+  trackEvent({ action, category, label }: TrackingEvent): void;
+}
 
 const googleAnalyticsProvider: TrackingProvider = {
-
   getName: (): string => {
-    return 'Google Analytics 4';
+    return "Google Analytics 4";
   },
 
-  isActive: (): boolean =>  {
+  isActive: (): boolean => {
     return TRACKING_GA_ON;
   },
 
   trackPageview: (url: string): void => {
-
-    window.gtag('config', GA_TRACKING_CODE, {
-      page_path: url,
-    })
+    window.gtag("config", GA_TRACKING_CODE, {
+      page_path: url
+    });
   },
 
-  trackEvent: ({action, category, label}: TrackingEvent): void => {
-
-    window.gtag('event', action, {
+  trackEvent: ({ action, category, label }: TrackingEvent): void => {
+    window.gtag("event", action, {
       event_category: category,
       event_label: label,
-      value: 0,
-    })
+      value: 0
+    });
   }
-
 };
 
-const trackingProviders: Array<TrackingProvider> = [
-    googleAnalyticsProvider
-];
+const trackingProviders: Array<TrackingProvider> = [googleAnalyticsProvider];
 
 export const trackPageview = (url: string): void => {
   if (!TRACKING_ON) {
@@ -61,7 +54,7 @@ export const trackPageview = (url: string): void => {
   for (let provider of trackingProviders) {
     if (provider.isActive()) {
       if (TRACKING_VERBOSE) {
-        console.log(provider.getName() + ' - trackPageview', url);
+        console.log(provider.getName() + " - trackPageview", url);
       }
 
       provider.trackPageview(url);
@@ -69,7 +62,7 @@ export const trackPageview = (url: string): void => {
   }
 };
 
-export const trackEvent = ({action, category, label}: TrackingEvent): void => {
+export const trackEvent = ({ action, category, label }: TrackingEvent): void => {
   if (!TRACKING_ON) {
     return;
   }
@@ -77,10 +70,10 @@ export const trackEvent = ({action, category, label}: TrackingEvent): void => {
   for (let provider of trackingProviders) {
     if (provider.isActive()) {
       if (TRACKING_VERBOSE) {
-        console.log(provider.getName() + ' - trackEvent', {action, category, label});
+        console.log(provider.getName() + " - trackEvent", { action, category, label });
       }
 
-      provider.trackEvent({action, category, label});
+      provider.trackEvent({ action, category, label });
     }
   }
 };

--- a/config/tracking.tsx
+++ b/config/tracking.tsx
@@ -1,0 +1,86 @@
+
+export const GA_TRACKING_CODE = process.env.GA_TRACKING_CODE;
+export const GA_DEBUG_MODE = process.env.GA_DEBUG_MODE;
+
+const TRACKING_ON = process.env.TRACKING !== 'off';
+const TRACKING_VERBOSE = process.env.TRACKING_VERBOSE === 'on';
+
+const TRACKING_GA_ON = process.env.TRACKING_PROVIDER_GA !== 'off';
+const TRACKING_KM_ON = process.env.TRACKING_PROVIDER_KM !== 'off';
+
+type TrackingEvent = {
+  action: string;
+  category: string;
+  label: string;
+};
+
+interface TrackingProvider {
+  getName(): string;
+  isActive(): boolean;
+  trackPageview(url: string): void;
+  trackEvent({action, category, label}: TrackingEvent): void;
+};
+
+const googleAnalyticsProvider: TrackingProvider = {
+
+  getName: (): string => {
+    return 'Google Analytics 4';
+  },
+
+  isActive: (): boolean =>  {
+    return TRACKING_GA_ON;
+  },
+
+  trackPageview: (url: string): void => {
+
+    window.gtag('config', GA_TRACKING_CODE, {
+      page_path: url,
+    })
+  },
+
+  trackEvent: ({action, category, label}: TrackingEvent): void => {
+
+    window.gtag('event', action, {
+      event_category: category,
+      event_label: label,
+      value: 0,
+    })
+  }
+
+};
+
+const trackingProviders: Array<TrackingProvider> = [
+    googleAnalyticsProvider
+];
+
+export const trackPageview = (url: string): void => {
+  if (!TRACKING_ON) {
+    return;
+  }
+
+  for (let provider of trackingProviders) {
+    if (provider.isActive()) {
+      if (TRACKING_VERBOSE) {
+        console.log(provider.getName() + ' - trackPageview', url);
+      }
+
+      provider.trackPageview(url);
+    }
+  }
+};
+
+export const trackEvent = ({action, category, label}: TrackingEvent): void => {
+  if (!TRACKING_ON) {
+    return;
+  }
+
+  for (let provider of trackingProviders) {
+    if (provider.isActive()) {
+      if (TRACKING_VERBOSE) {
+        console.log(provider.getName() + ' - trackEvent', {action, category, label});
+      }
+
+      provider.trackEvent({action, category, label});
+    }
+  }
+};

--- a/pages/[productSlug].tsx
+++ b/pages/[productSlug].tsx
@@ -5,6 +5,7 @@ import { useProduct } from "../hooks/useProduct";
 import { useMutation, useQueryClient } from "react-query";
 import { addItemToCart } from "../hooks/useCart";
 import { QueryKeys } from "../hooks/queryKeys";
+import * as tracking from '../config/tracking';
 
 const ProductDetail = () => {
   const router = useRouter();
@@ -17,12 +18,19 @@ const ProductDetail = () => {
     }
   });
 
+  React.useEffect(() => {
+    if (isSuccess) {
+      tracking.trackEvent({action: 'view-product', category: 'product-detail', label: data?.data?.attributes?.name});
+    }
+  }, [`${id}`, isSuccess]);
+
   if (isLoading) {
     return <div>Loading Product...</div>;
   }
 
   if (isSuccess) {
     const variants = data?.data.relationships.variants.data;
+
     const handleAddToCart = () =>
       addToCart.mutate({
         variant_id: Array.isArray(variants) ? variants[0].id : "",

--- a/pages/[productSlug].tsx
+++ b/pages/[productSlug].tsx
@@ -21,8 +21,8 @@ const ProductDetail = () => {
   React.useEffect(() => {
     if (isSuccess) {
       tracking.trackEvent({
-        action: "view-product",
-        category: "product-detail",
+        action: tracking.Action.VIEW_PRODUCT,
+        category: tracking.Category.PRODUCT_DETAIL,
         label: data?.data?.attributes?.name
       });
     }

--- a/pages/[productSlug].tsx
+++ b/pages/[productSlug].tsx
@@ -5,7 +5,7 @@ import { useProduct } from "../hooks/useProduct";
 import { useMutation, useQueryClient } from "react-query";
 import { addItemToCart } from "../hooks/useCart";
 import { QueryKeys } from "../hooks/queryKeys";
-import * as tracking from '../config/tracking';
+import * as tracking from "../config/tracking";
 
 const ProductDetail = () => {
   const router = useRouter();
@@ -20,7 +20,11 @@ const ProductDetail = () => {
 
   React.useEffect(() => {
     if (isSuccess) {
-      tracking.trackEvent({action: 'view-product', category: 'product-detail', label: data?.data?.attributes?.name});
+      tracking.trackEvent({
+        action: "view-product",
+        category: "product-detail",
+        label: data?.data?.attributes?.name
+      });
     }
   }, [`${id}`, isSuccess]);
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,8 @@ import { Hydrate } from "react-query/hydration";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { AuthProvider } from "../config/auth";
 import { Header } from "../components";
+import { useRouter } from "next/router";
+import * as tracking from '../config/tracking';
 
 // Styles
 import { ThemeProvider } from "@emotion/react";
@@ -22,6 +24,20 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       jssStyles.parentElement?.removeChild(jssStyles);
     }
   }, []);
+
+  const router = useRouter()
+
+  React.useEffect(() => {
+    const handleRouteChange = (url: string) => {
+      tracking.trackPageview(url);
+    }
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange)
+    };
+  }, [router.events])
 
   const renderHeader = () => {
     if (process.env.IS_MAINT_MODE !== "true") {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,7 +6,7 @@ import { ReactQueryDevtools } from "react-query/devtools";
 import { AuthProvider } from "../config/auth";
 import { Header } from "../components";
 import { useRouter } from "next/router";
-import * as tracking from '../config/tracking';
+import * as tracking from "../config/tracking";
 
 // Styles
 import { ThemeProvider } from "@emotion/react";
@@ -25,19 +25,19 @@ export default function MyApp({ Component, pageProps }: AppProps) {
     }
   }, []);
 
-  const router = useRouter()
+  const router = useRouter();
 
   React.useEffect(() => {
     const handleRouteChange = (url: string) => {
       tracking.trackPageview(url);
-    }
+    };
 
-    router.events.on('routeChangeComplete', handleRouteChange);
+    router.events.on("routeChangeComplete", handleRouteChange);
 
     return () => {
-      router.events.off('routeChangeComplete', handleRouteChange)
+      router.events.off("routeChangeComplete", handleRouteChange);
     };
-  }, [router.events])
+  }, [router.events]);
 
   const renderHeader = () => {
     if (process.env.IS_MAINT_MODE !== "true") {

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,7 +3,7 @@ import uaParser from "ua-parser-js";
 import { Context as ResponsiveContext, MediaQueryAllQueryable } from "react-responsive";
 import * as React from "react";
 import { ServerStyleSheets } from "@material-ui/core/styles";
-import * as tracking from '../config/tracking';
+import * as tracking from "../config/tracking";
 
 const withResponsiveContext = (App: any, req: any) => {
   const contextValue = (() => {
@@ -53,7 +53,8 @@ class MyDocument extends Document {
           />
           {/* <title>{process.env.SITE_TITLE}</title> */}
           <script
-            async src={"https://www.googletagmanager.com/gtag/js?id=" + tracking.GA_TRACKING_CODE}
+            async
+            src={"https://www.googletagmanager.com/gtag/js?id=" + tracking.GA_TRACKING_CODE}
           />
           <script
             dangerouslySetInnerHTML={{
@@ -65,10 +66,9 @@ class MyDocument extends Document {
                   'send_page_view': false,
                   'debug_mode': ${tracking.GA_DEBUG_MODE},
                 });
-              `,
+              `
             }}
           />
-
         </Head>
         <body>
           <Main />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,6 +3,7 @@ import uaParser from "ua-parser-js";
 import { Context as ResponsiveContext, MediaQueryAllQueryable } from "react-responsive";
 import * as React from "react";
 import { ServerStyleSheets } from "@material-ui/core/styles";
+import * as tracking from '../config/tracking';
 
 const withResponsiveContext = (App: any, req: any) => {
   const contextValue = (() => {
@@ -51,6 +52,23 @@ class MyDocument extends Document {
             href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
           />
           {/* <title>{process.env.SITE_TITLE}</title> */}
+          <script
+            async src={"https://www.googletagmanager.com/gtag/js?id=" + tracking.GA_TRACKING_CODE}
+          />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', "${tracking.GA_TRACKING_CODE}", {
+                  'send_page_view': false,
+                  'debug_mode': ${tracking.GA_DEBUG_MODE},
+                });
+              `,
+            }}
+          />
+
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
This PR implements Asana ticket "Setup Analytics & event tracking":

https://app.asana.com/0/1200646343193890/1200330326433105

The high level requirements for this feature (as communicated by Aaron) were as follows:

- we'll want to integrate Google Analytics events, and if possible Kissmetrics or maybe Segment
- we should write our "triggerEvent" or "trackEvent" (e.g. trackEvent("user_clicked_button", ...)) as generic as possible, including some new util/file w a func that wraps each event trigger
- GA will likely exist most of the time along with another service, so calling two or more service methods for each event would be ideal
- we could also start a separate util function for reporting/sending errors logs somewhere useful (Splunk, Datadog)
- we should capture (at least) these events:
	- [page views] (generic)
	- (Page name) - entered search query
	- (Page name) - Hit “enter” on search bar
	- (Page name) - Selected search suggestion
	- (Page name) - <Click/tap> signup [page view]
	- View Single Product - <slug> 

This was the general idea, and most of this has been implemented now. I've tested it with Google Analytics, and I've confirmed that the basics work. What has NOT been implemented are the following:

- the code has been designed so that for each event (page view or custom event) multiple services can be invoked (I'm calling them "providers"), however at this moment I've ONLY implemented one service/provider: Google Analytics. I've looked at Kissmetrics, but they do not seem to offer a free "trial", there was no signup option anywhere. Question - shall I try to implement Segment.io ? They do offer a "free" account option.

- I didn't include error logging/tracking (yet), but I saw that Google Analytics does support this (it's simply a custom event which you give the name/action "exception" and follow a convention for the other parameters) - and we could take a look at Splunk/Datadog as well
 
- Events to be captured: I did implement 'Hit “enter” on search bar' and 'Selected search suggestion', but not 'Entered search query' as I was not quite sure what that means ... and 'Click/tap> signup' is captured automatically as a Page View
(Page name) - entered search query

I've defined some configuration options which can be added to the appropriate `.env` file - here's an example of what's in my `.env.DNA.development` file: 

```
GA_TRACKING_CODE=G-XXXXXXXXXX
GA_DEBUG_MODE=true
TRACKING=on
TRACKING_VERBOSE=on
TRACKING_PROVIDER_GA=on
TRACKING_PROVIDER_KM=off
```

Note: none of these settings are required (all of them can be omitted), except GA_TRACKING_CODE (the Google Analytics Tracking Code) - without this, Google Analytics will obviously not work.

The other settings are as follows:

- `GA_DEBUG_MODE`: this can be set to true to enable Google Analytics' "debug view"; convenient during development, but not to be used in production.

- `TRACKING`: can be set to "on" or "off" (the default is "on" - set it to "off" if you want to disable tracking e.g. to prevent overhead etc during development)

- `TRACKING_VERBOSE`: can be set to "on" or "off" (the default is "off") - this simply does some additional "console.log" logging for dev/debug purposes (should be "off" in production)

-  `TRACKING_PROVIDER_GA`: can be set to "on" or "off" (the default is "on") - whether to invoke Google Analytics

-  `TRACKING_PROVIDER_KM`: can be set to "on" or "off" (the default is "on") - whether to invoke Kissmetrics (currently not implemented)

This is a basic (but functional) implementation, let me know if we need anything more than this.
