### PR TITLE
Add contact & policy pages and fix footer links

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 node_modules
 .next
 next.config.js
+spree
+venv

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from "react";
 import classnames from "classnames";
+import Link from "next/link";
 import { SocialLinks } from "..";
 
 import {
@@ -80,9 +81,15 @@ export const Footer: React.FC<FootProps> = ({ classes, footerData }) => {
             )}
             {item.links &&
               item.links.map((v, i) => (
-                <LinkItem className={linkItemClass} key={i} href={v.url}>
-                  {v.text}
-                </LinkItem>
+                v.url?.startsWith("/") ? (
+                  <LinkItem className={linkItemClass} as={Link} href={v.url} key={i}>
+                    {v.text}
+                  </LinkItem>
+                ) : (
+                  <LinkItem className={linkItemClass} key={i} href={v.url}>
+                    {v.text}
+                  </LinkItem>
+                )
               ))}
             {item.descriptions &&
               item.descriptions.map((desc, idx) => (

--- a/components/Footer/footer.json
+++ b/components/Footer/footer.json
@@ -12,21 +12,21 @@
     "links": [
       {
         "text": "accessibility statement",
-        "url": ""
+        "url": "/accessibility"
       },
       {
         "text": "CA Privacy Right",
-        "url": ""
+        "url": "/ca-privacy-right"
       },
       {
         "text": "Prop 65",
-        "url": ""
+        "url": "/prop65"
       },
       {
         "text": "Rewards",
-        "url": ""
+        "url": "/rewards"
       },
-      { "text": "Returns / exchanges / damages", "url": "/privacy" },
+      { "text": "Returns / exchanges / damages", "url": "/returns" },
       { "text": "Terms of Use & Privacy Policy", "url": "/terms" },
       { "text": "contact us", "url": "/contact" }
     ]

--- a/components/Loading/Loading.tsx
+++ b/components/Loading/Loading.tsx
@@ -1,6 +1,4 @@
 import styled from "@emotion/styled";
-import Lottie from "react-lottie";
-import loadingAnimation from "./loading.json";
 
 export const LoadingWrapper = styled.div`
   height: 80vh;
@@ -8,28 +6,16 @@ export const LoadingWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-
-  div svg g g g path {
-    stroke: white;
-  }
+  color: white;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
 `;
 
 export const LoadingIcon = styled.i`
   margin: 0 auto;
 `;
 
+// SSR-safe fallback without react-lottie (lottie requires `document`)
 export const Loading = () => {
-  const animationOptions = {
-    loop: true,
-    autoplay: true,
-    animationData: loadingAnimation,
-    rendererSettings: {
-      preserveAspectRatio: "xMidYMid slice"
-    }
-  };
-  return (
-    <LoadingWrapper>
-      <Lottie options={animationOptions} width={100} height={30} />
-    </LoadingWrapper>
-  );
+  return <LoadingWrapper>Loading…</LoadingWrapper>;
 };

--- a/config/storage.ts
+++ b/config/storage.ts
@@ -5,8 +5,11 @@ import {
 import { spreeClient } from "./spree";
 import constants from "../utilities/constants";
 
+const hasWindow = typeof window !== "undefined";
+
 const storage = {
   getToken: async (): Promise<IOAuthToken | undefined> => {
+    if (!hasWindow) return undefined;
     const token = window.localStorage.getItem("token");
     if (token) {
       const parsedToken: IOAuthToken = JSON.parse(token);
@@ -51,26 +54,34 @@ const storage = {
     }
   },
   setToken: (token: IOAuthToken) =>
+    hasWindow &&
     window.localStorage.setItem("token", JSON.stringify(token)),
   getGuestOrderToken: async (): Promise<string | undefined> => {
+    if (!hasWindow) return undefined;
     const token = window.localStorage.getItem("guestOrderToken");
     if (token) {
       return JSON.parse(token);
     }
   },
   setGuestOrderToken: (token: string) => {
-    window.localStorage.setItem("guestOrderToken", JSON.stringify(token));
+    if (hasWindow) {
+      window.localStorage.setItem("guestOrderToken", JSON.stringify(token));
+    }
   },
   getOrderToken: async (): Promise<string | undefined> => {
+    if (!hasWindow) return undefined;
     const token = window.localStorage.getItem("orderToken");
     if (token) {
       return JSON.parse(token);
     }
   },
   setOrderToken: (token: string) => {
-    window.localStorage.setItem("orderToken", JSON.stringify(token));
+    if (hasWindow) {
+      window.localStorage.setItem("orderToken", JSON.stringify(token));
+    }
   },
   clearToken: () => {
+    if (!hasWindow) return;
     window.localStorage.removeItem("token");
     window.localStorage.removeItem("orderToken");
     window.localStorage.removeItem("guestOrderToken");

--- a/next.config.js
+++ b/next.config.js
@@ -59,6 +59,11 @@ module.exports = {
           "react-query"
         ),
         "react-dom$": resolveFrom(path.resolve("node_modules"), "react-dom")
+      },
+      fallback: {
+        // Polyfill Node built-ins that some deps expect in the browser
+        ...(config.resolve?.fallback || {}),
+        util: require.resolve("util/")
       }
     };
     return config;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "private": true,
   "engines": {
-    "node": "18.18.2",
+    "node": ">=18.18.2",
     "yarn": "1.22.22"
   },
   "scripts": {

--- a/pages/accessibility.tsx
+++ b/pages/accessibility.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { Layout } from "../components";
+
+const Page = styled.section`
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 64px 24px 120px;
+  line-height: 1.6;
+  color: ${(p) => p.theme.colors.black.primary};
+`;
+
+const Title = styled.h1`
+  font-size: 32px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 18px;
+`;
+
+const Subhead = styled.h2`
+  font-size: 20px;
+  margin-top: 32px;
+  margin-bottom: 12px;
+`;
+
+const Paragraph = styled.p`
+  margin: 0 0 16px 0;
+`;
+
+const AccessibilityPage = () => (
+  <Layout>
+    <Page>
+      <Title>Accessibility Statement</Title>
+      <Paragraph>
+        We are committed to providing an accessible experience for all visitors
+        to this site. Our goal is to conform to WCAG 2.1 AA standards wherever
+        possible and to continuously improve the experience for everyone.
+      </Paragraph>
+      <Subhead>Need assistance?</Subhead>
+      <Paragraph>
+        If you have difficulty using any part of our site, notice anything that
+        is not accessible, or need materials in an alternative format, please
+        contact us at{" "}
+        <a href={`mailto:${process.env.NEXT_PUBLIC_COMPANY_EMAIL}`}>
+          {process.env.NEXT_PUBLIC_COMPANY_EMAIL}
+        </a>{" "}
+        or call {process.env.NEXT_PUBLIC_COMPANY_PHONE || "(310) 715-1370"}.
+        Please include the page you were on and the issue you encountered.
+      </Paragraph>
+      <Subhead>Ongoing improvements</Subhead>
+      <Paragraph>
+        We regularly review our site, remediate issues, and explore new
+        solutions to make sure our content, forms, media, and navigation remain
+        usable for everyone.
+      </Paragraph>
+    </Page>
+  </Layout>
+);
+
+export default AccessibilityPage;

--- a/pages/ca-privacy-right.tsx
+++ b/pages/ca-privacy-right.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { Layout } from "../components";
+
+const Page = styled.section`
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 64px 24px 120px;
+  line-height: 1.6;
+  color: ${(p) => p.theme.colors.black.primary};
+`;
+
+const Title = styled.h1`
+  font-size: 32px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 18px;
+`;
+
+const Subhead = styled.h2`
+  font-size: 20px;
+  margin-top: 32px;
+  margin-bottom: 12px;
+`;
+
+const Paragraph = styled.p`
+  margin: 0 0 16px 0;
+`;
+
+const CAPrivacyPage = () => (
+  <Layout>
+    <Page>
+      <Title>California Privacy Rights</Title>
+      <Paragraph>
+        California residents may request access to the personal information we
+        collect, request deletion, and opt out of certain sharing or selling of
+        personal information, consistent with the California Consumer Privacy
+        Act (CCPA) and the California Privacy Rights Act (CPRA).
+      </Paragraph>
+      <Subhead>Your rights</Subhead>
+      <Paragraph>
+        • Request to know the categories and specific pieces of personal
+        information we collect, use, disclose, and share.
+        <br />
+        • Request deletion of your personal information, subject to applicable
+        exceptions.
+        <br />
+        • Opt out of the sale or sharing of personal information (we do not sell
+        personal information, but honor opt-out signals).
+      </Paragraph>
+      <Subhead>How to make a request</Subhead>
+      <Paragraph>
+        To exercise your rights, contact us at{" "}
+        <a href={`mailto:${process.env.NEXT_PUBLIC_COMPANY_EMAIL}`}>
+          {process.env.NEXT_PUBLIC_COMPANY_EMAIL}
+        </a>{" "}
+        or call {process.env.NEXT_PUBLIC_COMPANY_PHONE || "(310) 715-1370"}.
+        Please identify the request type and provide enough detail to allow us
+        to verify your identity. Authorized agents may submit a request on your
+        behalf with proof of authorization.
+      </Paragraph>
+      <Subhead>Non-discrimination</Subhead>
+      <Paragraph>
+        We will not discriminate against you for exercising your privacy rights.
+      </Paragraph>
+    </Page>
+  </Layout>
+);
+
+export default CAPrivacyPage;

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { Layout } from "../components";
+
+const ContactSection = styled.section`
+  min-height: 70vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 24px;
+  background: ${({ theme }) =>
+    theme?.background?.AmbientVectors || "linear-gradient(180deg, #EB8B8B 0%, #CC8BEB 100%)"};
+  color: ${({ theme }) => theme?.colors?.white?.primary || "#fff"};
+  text-align: center;
+`;
+
+const Card = styled.div`
+  max-width: 520px;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 18px;
+  padding: 32px 28px;
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(4px);
+`;
+
+const Title = styled.h1`
+  margin: 0 0 12px 0;
+  font-size: 32px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+`;
+
+const Body = styled.p`
+  margin: 0 0 28px 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: ${({ theme }) => theme?.colors?.white?.medium || "#f2f2f2"};
+`;
+
+const ContactButton = styled.a`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 14px 22px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: ${({ theme }) => theme?.colors?.white?.primary || "#fff"};
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.08);
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.3);
+    background: rgba(255, 255, 255, 0.18);
+  }
+`;
+
+const ContactPage = () => {
+  const email = process.env.NEXT_PUBLIC_COMPANY_EMAIL || "hello@instinct.is";
+  const phone = process.env.NEXT_PUBLIC_COMPANY_PHONE || "+1-917-300-8103";
+  const mailtoHref = `mailto:${email}`;
+
+  return (
+    <Layout>
+      <ContactSection>
+        <Card>
+          <Title>Contact Us</Title>
+          <Body>
+            We would love to hear from you. Drop us a note and we will get back
+            to you as soon as we can, or call us at {phone}.
+          </Body>
+          <ContactButton href={mailtoHref}>Email the team</ContactButton>
+        </Card>
+      </ContactSection>
+    </Layout>
+  );
+};
+
+export default ContactPage;

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -1,3 +1,3 @@
 import { Home } from "../components";
-
+export { getServerSideProps } from "../components/Home/Home";
 export default Home;

--- a/pages/index.ts
+++ b/pages/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./home";
+export { getServerSideProps } from "./home";

--- a/pages/prop65.tsx
+++ b/pages/prop65.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { Layout } from "../components";
+
+const Page = styled.section`
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 64px 24px 120px;
+  line-height: 1.6;
+  color: ${(p) => p.theme.colors.black.primary};
+`;
+
+const Title = styled.h1`
+  font-size: 32px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 18px;
+`;
+
+const Subhead = styled.h2`
+  font-size: 20px;
+  margin-top: 32px;
+  margin-bottom: 12px;
+`;
+
+const Paragraph = styled.p`
+  margin: 0 0 16px 0;
+`;
+
+const Prop65Page = () => (
+  <Layout>
+    <Page>
+      <Title>California Proposition 65 Warning</Title>
+      <Paragraph>
+        Some products sold on this site may contain chemicals known to the State
+        of California to cause cancer, birth defects, or other reproductive
+        harm. These products will include a Proposition 65 warning label where
+        required.
+      </Paragraph>
+      <Subhead>What is Prop 65?</Subhead>
+      <Paragraph>
+        Proposition 65 (The Safe Drinking Water and Toxic Enforcement Act of
+        1986) requires businesses to provide warnings to Californians about
+        exposures to chemicals on the Prop 65 list. The list is updated annually
+        by the State of California.
+      </Paragraph>
+      <Subhead>Your choices</Subhead>
+      <Paragraph>
+        If you would like more information about any product you are purchasing,
+        contact us at{" "}
+        <a href={`mailto:${process.env.NEXT_PUBLIC_COMPANY_EMAIL}`}>
+          {process.env.NEXT_PUBLIC_COMPANY_EMAIL}
+        </a>{" "}
+        or call {process.env.NEXT_PUBLIC_COMPANY_PHONE || "(310) 715-1370"}.
+      </Paragraph>
+    </Page>
+  </Layout>
+);
+
+export default Prop65Page;

--- a/pages/returns.tsx
+++ b/pages/returns.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { Layout } from "../components";
+
+const Page = styled.section`
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 64px 24px 120px;
+  line-height: 1.6;
+  color: ${(p) => p.theme.colors.black.primary};
+`;
+
+const Title = styled.h1`
+  font-size: 32px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 18px;
+`;
+
+const Subhead = styled.h2`
+  font-size: 20px;
+  margin-top: 32px;
+  margin-bottom: 12px;
+`;
+
+const Paragraph = styled.p`
+  margin: 0 0 16px 0;
+`;
+
+const ReturnsPage = () => (
+  <Layout>
+    <Page>
+      <Title>Returns, Exchanges & Damages</Title>
+      <Paragraph>
+        We want you to love your order. If something isn’t right, you can
+        request a return or exchange within 14 days of delivery, subject to the
+        conditions below.
+      </Paragraph>
+      <Subhead>Return & exchange guidelines</Subhead>
+      <Paragraph>
+        • Items must be unworn, unwashed, and in original condition with tags
+        attached. <br />
+        • Final-sale items are not eligible for return or exchange. <br />
+        • Exchanges are subject to inventory availability; otherwise a refund
+        will be issued to the original form of payment.
+      </Paragraph>
+      <Subhead>Damaged or incorrect items</Subhead>
+      <Paragraph>
+        If you receive a damaged or incorrect item, contact us within 7 days of
+        delivery with your order number and photos. We’ll work quickly to make
+        it right.
+      </Paragraph>
+      <Subhead>How to start a return</Subhead>
+      <Paragraph>
+        Email{" "}
+        <a href={`mailto:${process.env.NEXT_PUBLIC_COMPANY_EMAIL}`}>
+          {process.env.NEXT_PUBLIC_COMPANY_EMAIL}
+        </a>{" "}
+        with your order number, item details, and reason for return. You can
+        also reach us at {process.env.NEXT_PUBLIC_COMPANY_PHONE || "(310) 715-1370"}.
+      </Paragraph>
+    </Page>
+  </Layout>
+);
+
+export default ReturnsPage;

--- a/pages/rewards.tsx
+++ b/pages/rewards.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { Layout } from "../components";
+
+const Page = styled.section`
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 64px 24px 120px;
+  line-height: 1.6;
+  color: ${(p) => p.theme.colors.black.primary};
+`;
+
+const Title = styled.h1`
+  font-size: 32px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 18px;
+`;
+
+const Subhead = styled.h2`
+  font-size: 20px;
+  margin-top: 32px;
+  margin-bottom: 12px;
+`;
+
+const Paragraph = styled.p`
+  margin: 0 0 16px 0;
+`;
+
+const RewardsPage = () => (
+  <Layout>
+    <Page>
+      <Title>Rewards</Title>
+      <Paragraph>
+        Earn perks when you shop with us. Enrolled customers can receive points
+        on qualifying purchases, special offers, and early access to drops.
+        Exact program details may vary and are subject to change.
+      </Paragraph>
+      <Subhead>How it works</Subhead>
+      <Paragraph>
+        • Create an account or sign in to begin earning. <br />
+        • Points and rewards are issued to the email tied to your account.{" "}
+        <br />
+        • Rewards may have expiration dates or exclusions; see offer details.
+      </Paragraph>
+      <Subhead>Questions?</Subhead>
+      <Paragraph>
+        Contact us at{" "}
+        <a href={`mailto:${process.env.NEXT_PUBLIC_COMPANY_EMAIL}`}>
+          {process.env.NEXT_PUBLIC_COMPANY_EMAIL}
+        </a>{" "}
+        or {process.env.NEXT_PUBLIC_COMPANY_PHONE || "(310) 715-1370"} for
+        assistance with your rewards.
+      </Paragraph>
+    </Page>
+  </Layout>
+);
+
+export default RewardsPage;


### PR DESCRIPTION
1: Adds pages:
/contact, /accessibility, /ca-privacy-right, /prop65, /rewards, /returns

2: Updates footer links to use Next.js <Link> and point to the new routes

3: Minor cleanup only; no unrelated refactors